### PR TITLE
Enable use of local IP address for update of DDNS service.

### DIFF
--- a/EasyDDNS.cpp
+++ b/EasyDDNS.cpp
@@ -38,27 +38,39 @@ void EasyDDNSClass::client(String ddns_domain, String ddns_username, String ddns
   ddns_p = ddns_password;
 }
 
-void EasyDDNSClass::update(unsigned long ddns_update_interval){
+void EasyDDNSClass::update(unsigned long ddns_update_interval, bool use_local_ip ){
 
     interval = ddns_update_interval;
 
     unsigned long currentMillis = millis(); // Calculate Elapsed Time & Trigger
     if(currentMillis - previousMillis >= interval) {
         previousMillis = currentMillis;
-		
+
+
+
+	if ( use_local_ip ) {
+	  IPAddress ipAddress = WiFi.localIP();
+	  
+	  new_ip = String(ipAddress[0]) + String(".") +			\
+	    String(ipAddress[1]) + String(".") +			\
+	    String(ipAddress[2]) + String(".") +			\
+	    String(ipAddress[3]);
+
+	} else {	
 // ######## GET PUBLIC IP ######## //
-        HTTPClient http;
-        http.begin("http://ipv4bot.whatismyipaddress.com/");
-        int httpCode = http.GET();
-        if(httpCode > 0) {
-          if(httpCode == HTTP_CODE_OK) {
-                new_ip = http.getString();
-              }
-        }else{
+          HTTPClient http;
+          http.begin("http://ipv4bot.whatismyipaddress.com/");
+          int httpCode = http.GET();
+          if(httpCode > 0) {
+            if(httpCode == HTTP_CODE_OK) {
+                  new_ip = http.getString();
+                }
+          }else{
+            http.end();
+            return;
+          }
           http.end();
-          return;
-        }
-        http.end();
+	}
 		
 // ######## GENERATE UPDATE URL ######## //
         if(ddns_choice == "duckdns"){

--- a/EasyDDNS.h
+++ b/EasyDDNS.h
@@ -47,7 +47,7 @@ class EasyDDNSClass{
 public:
   void service(String ddns_service);
   void client(String ddns_domain, String ddns_username,String ddns_password = "");
-  void update(unsigned long ddns_update_interval);
+  void update(unsigned long ddns_update_interval, bool use_local_ip = false);
 
 private:
   unsigned long interval;

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ For **enom**, Use `EasyDDNS.client("host","domain","password");`<br>
 where `host` is something like `www`, and `domain` can be `example.com` <br>
 
 - Atlast Use `EasyDDNS.update(10000);` in loop() to set Interval to Check for New Public IP.
+<br>
+OR
+<br>
+Use `EasyDDNS.update(10000, true);` in loop() to set Interval to Check for New Local Network IP so can use DDNS for devices that don't support mDNS to access within local network. 
 
 **5 Ready to Use Examples are Provided with Library for DuckDNS, DynDNS, Dynu, No-ip & enom.**
 

--- a/examples/DuckDNS_LocalIP_Client/DuckDNS_LocalIP_Client.ino
+++ b/examples/DuckDNS_LocalIP_Client/DuckDNS_LocalIP_Client.ino
@@ -1,0 +1,36 @@
+/*
+######### DuckDNS Update with Local IP Client for ESP8266 ##########
+This Example Explains the Use of EasyDDNS Library with DuckDNS Service
+and Checks for a New local IP Every 10 Seconds.
+
+
+Author: Ayush Sharma, with very minor changes by Clint Cooper 
+
+*/
+#include <EasyDDNS.h>
+#include <ESP8266WiFi.h>
+
+const char* ssid = "your-ssid";
+const char* password = "your-password";
+
+WiFiServer server(80);
+
+
+void setup() {
+Serial.begin(115200);
+WiFi.mode(WIFI_STA);
+WiFi.begin(ssid, password);
+while (WiFi.status() != WL_CONNECTED) {
+delay(500);
+Serial.print(".");
+}
+Serial.println(WiFi.localIP()); // Print the IP address
+server.begin();
+
+EasyDDNS.service("duckdns");    // Enter your DDNS Service Name - "duckdns" / "noip"
+EasyDDNS.client("domain","token");    // Enter ddns Domain & Token | Example - "esp.duckdns.org","1234567"
+}
+
+void loop() {
+EasyDDNS.update(10000, true); // Check for New Ip Every 10 Seconds, pass in true to use local Wifi IP address
+}


### PR DESCRIPTION
Added flag to update() method to use local ip address but set default for flag to maintain backwards compatibility.

Added example based off duckdns example. 
