### PR TITLE
Add support for the freedns.afraid.org

### DIFF
--- a/EasyDDNS.cpp
+++ b/EasyDDNS.cpp
@@ -69,6 +69,8 @@ void EasyDDNSClass::update(unsigned long ddns_update_interval, bool use_local_ip
       update_url = "http://" + ddns_u + ":" + ddns_p + "@dyndns.strato.com/nic/update?hostname=" + ddns_d + "&myip=" + new_ip + "";
     } else if (ddns_choice == "freemyip") {
       update_url = "http://freemyip.com/update?domain=" + ddns_d + "&token=" + ddns_u + "&myip=" + new_ip + "";
+    } else if (ddns_choice == "afraid.org") {
+      update_url = "http://sync.afraid.org/u/" + ddns_u + "/";
     } else {
       Serial.println("## INPUT CORRECT DDNS SERVICE NAME ##");
       return;

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ EasyDDNS Library can be implemented in your major projects as a sidekick. It is 
 - selfhost.de
 - strato
 - freemyip
+- afraid.org
 
 If you don't know what's DDNS, then you can find more info about DDNS here: [WiKipedia](https://en.wikipedia.org/wiki/Dynamic_DNS)
 

--- a/examples/DDNS_Client/DDNS_Client.ino
+++ b/examples/DDNS_Client/DDNS_Client.ino
@@ -36,6 +36,7 @@ void setup() {
     - "dyndns.it"
     - "strato"
     - "freemyip"
+    - "afraid.org"
   */
   EasyDDNS.service("duckdns");
 

--- a/examples/LocalIP_DDNS_Client/LocalIP_DDNS_Client.ino
+++ b/examples/LocalIP_DDNS_Client/LocalIP_DDNS_Client.ino
@@ -41,6 +41,7 @@ void setup() {
     - "dyndns.it"
     - "strato"
     - "freemyip"
+    - "afraid.org"
   */
   EasyDDNS.service("duckdns");
 

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
       "maintainer": true
     }
   ],
-  "version": "1.5.8",
+  "version": "1.5.9",
   "frameworks": "arduino",
   "platforms": "espressif"
 }


### PR DESCRIPTION
Hi! 
This pull request adds support for the [afraid.org](https://freedns.afraid.org/) DDNS service.
URL pattern: `http://sync.afraid.org/u/{token}/`

Usage example:
```
String token = "your_token"; 
EasyDDNS.service("afraid.org");
EasyDDNS.client("", token);
```


