### PR TITLE
Fix #23 - Support OVH Dyndns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ version: ~> 1.0
 
 language: python
 python:
-    - "2.7"
+    - "3.6"
 sudo: false
 cache:
     directories:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ EasyDDNS Library can be implemented in your major projects as a sidekick. It is 
 - strato
 - freemyip
 - afraid.org
+- OVH.com
 
 If you don't know what's DDNS, then you can find more info about DDNS here: [WiKipedia](https://en.wikipedia.org/wiki/Dynamic_DNS)
 


### PR DESCRIPTION
Hello,

I've create a new merge request to handle change for Travis too.

This merge request restore build on Travis by updating Python version and support Dyndns on OVH domains (Fix #23).

Have a good day :)
Thomas S.